### PR TITLE
fix: set navigation to the center

### DIFF
--- a/frontend/src/components/Header/Header.scss
+++ b/frontend/src/components/Header/Header.scss
@@ -6,6 +6,7 @@
   min-height: 70px;
 
   .header__content {
+    position: relative;
     @include flex(space-between, center);
     width: 100%;
     margin: 0 60px;

--- a/frontend/src/components/Nav/Nav.scss
+++ b/frontend/src/components/Nav/Nav.scss
@@ -2,6 +2,10 @@
 
 .nav {
   @include flex($align: center);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   gap: 28px;
 
   &__link {


### PR DESCRIPTION
Блок навигации в хедере был не по центру и зависил от размера боковых элементов. Теперь он ровно по центру экрана
![image](https://user-images.githubusercontent.com/81195644/181854200-9f355984-75ce-4e62-af40-483b3fc4c7ef.png)
