### PR TITLE
Fix/change the mixin at the header button

### DIFF
--- a/frontend/src/components/Header/Header.scss
+++ b/frontend/src/components/Header/Header.scss
@@ -28,23 +28,24 @@
         @include font(14px, 500, 16px);
         color: $brown;
         text-decoration: none;
+
+        .header__button {
+          @include interactive();
+          width: 120px;
+          height: 30px;
+          margin: 0;
+          padding: 0;
+          @include font(14px, 500, 16px);
+          color: $brown;
+          background-color: $green;
+          border-radius: 5px;
+          border: none;
+          cursor: pointer;
+          filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+        }
         &:hover {
           color: $coral;
         }
-      }
-
-      .header__button {
-        width: 120px;
-        height: 30px;
-        margin: 0;
-        padding: 0;
-        @include font(14px, 500, 16px);
-        color: $brown;
-        background-color: $green;
-        border-radius: 5px;
-        border: none;
-        cursor: pointer;
-        filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
       }
     }
   }


### PR DESCRIPTION
В хедере кнопка "Зарегистрироваться" должна использовать новый миксин, который увеличивает её на 1.1.
Теперь она использует новый миксин
![image](https://user-images.githubusercontent.com/81195644/181853840-d261c33c-2c28-4bf1-b7cb-e30a9cba3f80.png)
