### PR TITLE
feat: add feedback api & error popup

### DIFF
--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -58,6 +58,12 @@ function App() {
       .catch(() => setErrorMesage(errorMessages.BadEmailOrPassword));
   };
 
+  const feedback = (values: any) => {
+    Api.feedback(values)
+      .then(() => setErrorMesage(errorMessages.SuccessFeedback))
+      .catch(() => setErrorMesage(errorMessages.BadFeedback));
+  };
+
   const handleloggedOutClick = () => {
     localStorage.removeItem("token");
     setLoggedIn(false);
@@ -70,7 +76,16 @@ function App() {
         {pathWithHeader.includes(pathname) && <Header loggedIn={loggedIn} />}
 
         <Routes>
-          <Route path="/" element={<Main />} />
+          <Route
+            path="/"
+            element={
+              <Main
+                handleFeedback={feedback}
+                errorMesage={errorMesage}
+                setErrorMesage={setErrorMesage}
+              />
+            }
+          />
           <Route path="/dishes" element={<Dishes />} />
           <Route path="/semis" element={<Semis />} />
           <Route path="/foodstuff" element={<Foodstuff />} />

--- a/frontend/src/components/Main/About/About.tsx
+++ b/frontend/src/components/Main/About/About.tsx
@@ -1,24 +1,46 @@
-import { FC } from "react";
+import { FC, SetStateAction } from "react";
 import FeedbackForm from "../FeedbackForm/FeedbackForm";
 import { about } from "../../../utils/textConstants";
 import "./About.scss";
+import Popup from "../../Popup/Popup";
 
 interface AboutProps {
   aboutTitle: string;
   aboutParagraphOne: string;
   aboutParagraphTwo: string;
+  handleFeedback: (values: any) => void;
+  errorMesage: string;
+  setErrorMesage: React.Dispatch<SetStateAction<string>>;
 }
 
-const About: FC<AboutProps> = ({ aboutTitle, aboutParagraphOne, aboutParagraphTwo }) => {
+const About: FC<AboutProps> = ({
+  aboutTitle,
+  aboutParagraphOne,
+  aboutParagraphTwo,
+  handleFeedback,
+  errorMesage,
+  setErrorMesage,
+}) => {
+  console.log(errorMesage);
+
+  const closePopup = (evt: any) => {
+    if (evt.currentTarget === evt.target || evt.target.classList.contains("popup__close-button")) {
+      setErrorMesage("");
+    }
+  };
+
   return (
-    <section className="about">
-      <div className="about__wave about__wave_blue"></div>
-      <h2 className="about__title">{aboutTitle}</h2>
-      <p className="about__text">{aboutParagraphOne}</p>
-      <p className="about__text">{aboutParagraphTwo}</p>
-      <FeedbackForm buttonText={about.SendButton} />
-      <div className="about__wave about__wave_green"></div>
-    </section>
+    <>
+      {errorMesage && <Popup text={errorMesage} closePopup={closePopup} />}
+      <section className="about">
+        <div className="about__wave about__wave_blue"></div>
+        <h2 className="about__title">{aboutTitle}</h2>
+        <p className="about__text">{aboutParagraphOne}</p>
+        <p className="about__text">{aboutParagraphTwo}</p>
+        <FeedbackForm buttonText={about.SendButton} handleFeedback={handleFeedback} />
+        <div className="about__wave about__wave_green"></div>
+      </section>
+    </>
   );
 };
 

--- a/frontend/src/components/Main/FeedbackForm/FeedbackForm.tsx
+++ b/frontend/src/components/Main/FeedbackForm/FeedbackForm.tsx
@@ -1,27 +1,19 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Validation } from "../../../utils/Validation";
 import "./FeedbackForm.scss";
 
 interface FormProps {
   buttonText: string;
+  handleFeedback: (values: any) => void;
 }
 
-const FeedbackForm: FC<FormProps> = ({ buttonText }) => {
+const FeedbackForm: FC<FormProps> = ({ buttonText, handleFeedback }) => {
   const { values, handleChange, errors, isValid } = Validation();
 
   function handleSubmit(evt: any) {
     evt.preventDefault();
-    handleSubmitForm(values);
+    handleFeedback(values);
   }
-
-  const handleSubmitForm = (values: any) => {
-    // Api.register(values)
-    //   .then((data) => {
-    //     alert("Регистрация пользователя " + data.username + " прошла успешно");
-    //     navigate("/dishes");
-    //   })
-    //   .catch((error) => console.error(error));
-  };
 
   return (
     <form className="feedback" onSubmit={handleSubmit}>
@@ -30,31 +22,31 @@ const FeedbackForm: FC<FormProps> = ({ buttonText }) => {
           <div className="feedback__input-container">
             <input
               type="text"
-              name="username"
+              name="title"
               autoComplete="off"
-              minLength={2}
+              minLength={1}
               maxLength={150}
               placeholder="Имя"
               className="feedback__input"
               required
               onChange={handleChange}
             />
-            <span className="feedback__input-error">{errors.username}</span>
+            <span className="feedback__input-error">{errors.title}</span>
           </div>
 
           <div className="feedback__input-container">
             <input
               type="email"
-              name="email"
+              name="return_address"
               autoComplete="off"
-              minLength={2}
+              minLength={1}
               maxLength={30}
               placeholder="Email"
               className="feedback__input"
               required
               onChange={handleChange}
             />
-            <span className="feedback__input-error">{errors.email}</span>
+            <span className="feedback__input-error">{errors.return_address}</span>
           </div>
         </div>
 
@@ -69,16 +61,16 @@ const FeedbackForm: FC<FormProps> = ({ buttonText }) => {
 
       <div className="feedback__input-container feedback__input-container_text">
         <textarea
-          name="text"
+          name="message"
           autoComplete="off"
-          minLength={2}
-          // maxLength={150}
+          minLength={1}
+          maxLength={150}
           placeholder="Текст..."
           className="feedback__input feedback__input_text"
           required
           onChange={handleChange}
         ></textarea>
-        <span className="feedback__input-error">{errors.text}</span>
+        <span className="feedback__input-error">{errors.message}</span>
       </div>
     </form>
   );

--- a/frontend/src/components/Main/Main.tsx
+++ b/frontend/src/components/Main/Main.tsx
@@ -1,10 +1,16 @@
-import { FC } from "react";
+import { FC, SetStateAction } from "react";
 import "./Main.scss";
 import Greeting from "./Greeting/Greeting";
 import About from "./About/About";
 import { greeting, about } from "../../utils/textConstants";
 
-const Main: FC = () => {
+interface MainProps {
+  handleFeedback: (values: any) => void;
+  errorMesage: string;
+  setErrorMesage: React.Dispatch<SetStateAction<string>>;
+}
+
+const Main: FC<MainProps> = ({ handleFeedback, errorMesage, setErrorMesage }) => {
   return (
     <section>
       <Greeting
@@ -16,6 +22,9 @@ const Main: FC = () => {
         aboutTitle={about.Title}
         aboutParagraphOne={about.ParagraphOne}
         aboutParagraphTwo={about.ParagraphTwo}
+        handleFeedback={handleFeedback}
+        errorMesage={errorMesage}
+        setErrorMesage={setErrorMesage}
       />
     </section>
   );

--- a/frontend/src/utils/Api.ts
+++ b/frontend/src/utils/Api.ts
@@ -38,3 +38,16 @@ export const authorize = async (data: string) => {
       return res.data;
     });
 };
+
+export const feedback = async (data: string) => {
+  return await axios
+    .post("/api/send_mail/", data, {
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    })
+    .then((res) => {
+      return res.data;
+    });
+};

--- a/frontend/src/utils/textConstants.ts
+++ b/frontend/src/utils/textConstants.ts
@@ -50,6 +50,8 @@ export const about = {
 export const errorMessages = {
   DuplicateEmail: "Пользователь с такой почтой уже зарегистрирован",
   BadEmailOrPassword: "Неправильные почта или пароль",
+  BadFeedback: "Ой, что-то пошло не так",
+  SuccessFeedback: "Спасибо за обратную связь",
 };
 
 export const questions = {


### PR DESCRIPTION
Поправил имена полей согласно api, реализовал api фидбэка и прокинул popup как в регистрации и авторизации. Из-за глубокой вложенности компонента FeedbackForm (
`Api -> Main -> About -> FeedbackForm` ) Пришлось глубоко прокидывать пропсы для реализации работы попапа. Как думаете что с этим делать? Не пора ли изучить Redux? Мне кажется он для этого и создан.
![image](https://user-images.githubusercontent.com/81195644/183079310-0fff719b-c0fb-42ae-8694-52cb6b91f424.png)
